### PR TITLE
Add age conditioning and single-style LoRA support

### DIFF
--- a/data_loaders/get_data.py
+++ b/data_loaders/get_data.py
@@ -50,7 +50,7 @@ def get_dataset(name, num_frames, split='train', hml_mode='train',
 
     if name in ["humanml", "kit"]:
         # Text datasets (use their own internal dirs and options)
-        dataset = DATA(split=split, num_frames=num_frames, mode=hml_mode)
+        dataset = DATA(split=split, num_frames=num_frames, mode=hml_mode, **kwargs)
     elif name == "100style":
         dataset = DATA(styles, split, motion_type_to_exclude=motion_type_to_exclude)
     elif name == "vc":

--- a/data_loaders/tensors.py
+++ b/data_loaders/tensors.py
@@ -47,6 +47,10 @@ def collate(batch):
         actionbatch = [b['action'] for b in notnone_batches]
         cond['y'].update({'action': torch.as_tensor(actionbatch).unsqueeze(1)})
 
+    if 'age' in notnone_batches[0]:
+        agebatch = [b['age'] for b in notnone_batches]
+        cond['y'].update({'age': torch.as_tensor(agebatch).unsqueeze(1).float()})
+
     # collate action textual names
     if 'action_text' in notnone_batches[0]:
         action_text = [b['action_text']for b in notnone_batches]
@@ -57,12 +61,17 @@ def collate(batch):
 # an adapter to our collate func
 def t2m_collate(batch):
     # batch.sort(key=lambda x: x[3], reverse=True)
-    adapted_batch = [{
-        'inp': torch.tensor(b[4].T).float().unsqueeze(1), # [seqlen, J] -> [J, 1, seqlen]
-        'text': b[2], #b[0]['caption']
-        'tokens': b[6],
-        'lengths': b[5],
-    } for b in batch]
+    adapted_batch = []
+    for b in batch:
+        item = {
+            'inp': torch.tensor(b[4].T).float().unsqueeze(1),  # [seqlen, J] -> [J, 1, seqlen]
+            'text': b[2],
+            'tokens': b[6],
+            'lengths': b[5],
+        }
+        if len(b) > 7:
+            item['age'] = b[7]
+        adapted_batch.append(item)
     return collate(adapted_batch)
 
 

--- a/train/train_mdm.py
+++ b/train/train_mdm.py
@@ -50,7 +50,8 @@ def main():
     #     prior_data = None
     if args.lora_finetune:
         print("creating style data loader...")
-        data = get_dataset_loader(name=args.dataset, batch_size=args.batch_size, num_frames=args.num_frames, styles=tuple(args.styles))
+        data = get_dataset_loader(name=args.dataset, batch_size=args.batch_size, num_frames=args.num_frames,
+                                  styles=tuple(args.styles), age_cond=args.age_cond)
 
         if args.lambda_prior_preserv > 0:
             print("creating prior data loader...", flush=True)

--- a/utils/parser_util.py
+++ b/utils/parser_util.py
@@ -61,6 +61,7 @@ def add_lora_options(parser):
     group.add_argument("--lora_layer", default=-100, type=int, help='Transformers layer to use for lora, negative for all layers.')
     group.add_argument("--no_lora_q", action='store_true', help='remove lora adapter from query')
     group.add_argument("--lora_ff", action='store_true', help='add lora adapter to feed forward layers')
+    group.add_argument("--age_cond", action='store_true', help="Enable age MLP conditioning.")
 
 
 def add_base_options(parser):


### PR DESCRIPTION
## Summary
- add `--age_cond` flag to parser and dataset loader so age metadata flows into `cond['y']['age']`
- embed age via MLP in MDM and support named LoRA adapters with `set_active_lora`
- update training loop for single-style LoRA finetuning and guard generation when dataset lacks style tokens

## Testing
- `python -m py_compile utils/parser_util.py data_loaders/get_data.py data_loaders/humanml/data/dataset.py data_loaders/tensors.py model/mdm.py train/train_mdm.py train/training_loop.py`
- `python train/train_mdm.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689bdf31ea688327a15b3760d6d334e1